### PR TITLE
Fix warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ _build
 .idea
 rebar3.crashdump
 **~
+rebar3

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,2 @@
 {erl_opts, [debug_info]}.
 {deps, []}.
-
-{shell, [
-  % {config, "config/sys.config"},
-    {apps, [redis]}
-]}.

--- a/src/redis.app.src
+++ b/src/redis.app.src
@@ -1,0 +1,9 @@
+{application, redis,
+    [{description, "redis is an application and library implementing redis protocol in Erlang"},
+     {vsn, semver},
+     {registered, []},
+     {env, []},
+     {applications, [kernel, stdlib]},
+     {licenses, ["ISC License"]},
+     {links, [{"Github", "https://github.com/niamtokik/redis.git"}]}]
+}.

--- a/src/redis.erl
+++ b/src/redis.erl
@@ -6,7 +6,7 @@
 -export([encode/1, decode/1]).
 -include_lib("eunit/include/eunit.hrl").
 
--type encode_error() :: {error, bitstring() | binary()}.
+%-type encode_error() :: {error, bitstring() | binary()}.
 -type encode_integer() :: integer().
 -type encode_string() :: bitstring() | binary().
 -type encode_bulk_string() :: {bulk_string, bitstring()}.
@@ -211,12 +211,12 @@ decode_integer(<<Char, Rest/bitstring>>, Buffer)
 %%--------------------------------------------------------------------
 %%
 %%--------------------------------------------------------------------
-decode_separator(Bitstring) ->
-    case binary:split(Bitstring, <<"\r\n">>) of
-        [<<>>] -> {ok, <<>>};
-        [<<>>,<<>>] -> {ok, <<>>};
-        [Value,Rest] -> {ok, Value, Rest}
-    end.
+%decode_separator(Bitstring) ->
+%    case binary:split(Bitstring, <<"\r\n">>) of
+%        [<<>>] -> {ok, <<>>};
+%        [<<>>,<<>>] -> {ok, <<>>};
+%        [Value,Rest] -> {ok, Value, Rest}
+%    end.
 
 %%--------------------------------------------------------------------
 %%
@@ -265,9 +265,9 @@ decode_error(Bitstring) ->
 
 decode_error(<<"\r\n">>, Buffer) ->
     {ok, {error, Buffer}};
-decode_error(<<"\r", Rest/bitstring>>, _) ->
+decode_error(<<"\r", _/bitstring>>, _) ->
     {error, badchar};
-decode_error(<<"\n", Rest/bitstring>>, _) ->
+decode_error(<<"\n", _/bitstring>>, _) ->
     {error, badchar};
 decode_error(<<Char, Rest/bitstring>>, Buffer) ->
     decode_error(Rest, <<Buffer/bitstring, Char>>).

--- a/src/redis.erl
+++ b/src/redis.erl
@@ -9,7 +9,7 @@
 %-type encode_error() :: {error, bitstring() | binary()}.
 -type encode_integer() :: integer().
 -type encode_string() :: bitstring() | binary().
--type encode_bulk_string() :: {bulk_string, bitstring()}.
+-type encode_bulk_string() :: {bulk_string, bitstring() | null} | list() | {error, binary()}.
 -type encode_array() :: [encode_integer() |
                          encode_string() |
                          encode_bulk_string()].
@@ -128,7 +128,7 @@ encode_valid_char(Bitstring)
       List :: list(),
       Buffer :: bitstring() | binary(),
       Counter :: integer(),
-      Return :: bitstring() | binary().
+      Return :: {ok, bitstring() | binary(), integer()}.
 encode_array([], Buffer, Counter) ->
     {ok, Buffer, Counter};
 encode_array([H|T], Buffer, Counter) ->


### PR DESCRIPTION
**Purposes of changes:**
* Fix boot warning:
```sh
./rebar3 shell
===> Verifying dependencies...
Erlang/OTP 23 [erts-11.0.3] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [hipe]

Eshell V11.0.3  (abort with ^G)
1> ===> Failed to boot redis for reason {"no such file or directory", 
                                                 "redis.app"}
```
* Fix compile warnings:
```sh
$ ./rebar3 compile
src/redis.erl:9: Warning: type encode_error() is unused
src/redis.erl:214: Warning: function decode_separator/1 is unused
src/redis.erl:268: Warning: variable 'Rest' is unused
src/redis.erl:270: Warning: variable 'Rest' is unused
```
* Updated `.gitignore` - added `rebar3`
* Added [SemVer](https://semver.org/) for release versions
* Deleted `shell` section from `rebar.config`
* Fixed dialyzer:
```sh
src/redis.erl
  60: Function encode_test/0 has no local return
  75: The created fun has no local return
  76: The call redis:encode({'bulk_string', 'null'}) breaks the contract (Data) -> Return when Data :: encode_types(), Return :: encode_return_ok() | encode_return_error()
 127: Invalid type specification for function redis:encode_array/3. The success typing is ([bitstring() | [bitstring() | [any()] | integer() | {_,_}] | integer() | {'bulk_string','null' | binary()} | {'error',bitstring()}],bitstring(),non_neg_integer()) -> {'ok',bitstring(),non_neg_integer()}
```