### PR TITLE
WIP: Redis command implementation

### DIFF
--- a/src/redis.erl
+++ b/src/redis.erl
@@ -5,20 +5,7 @@
 -module(redis).
 -export([encode/1, decode/1]).
 -include_lib("eunit/include/eunit.hrl").
-
-%-type encode_error() :: {error, bitstring() | binary()}.
--type encode_integer() :: integer().
--type encode_string() :: bitstring() | binary().
--type encode_bulk_string() :: {bulk_string, bitstring() | null} | list() | {error, binary()}.
--type encode_array() :: [encode_integer() |
-                         encode_string() |
-                         encode_bulk_string()].
--type encode_types() :: encode_integer() | 
-                        encode_string() |
-                        encode_bulk_string() |
-                        encode_array().
--type encode_return_ok() :: bitstring() | binary().
--type encode_return_error() :: {error, atom()}.
+-include("redis.hrl").
 
 %%-------------------------------------------------------------------
 %% @doc
@@ -178,7 +165,8 @@ decode_test() ->
     ].
 
 %%--------------------------------------------------------------------
-%%
+%% @doc
+%% @end
 %%--------------------------------------------------------------------
 decode_string(Bitstring) ->
     decode_string(Bitstring, <<>>).
@@ -195,7 +183,8 @@ decode_string(<<Char, Rest/bitstring>>, Buffer) ->
     decode_string(Rest, <<Buffer/bitstring, Char>>).
 
 %%--------------------------------------------------------------------
-%%
+%% @doc
+%% @end
 %%--------------------------------------------------------------------
 decode_integer(Integer) ->
     decode_integer(Integer, <<>>).
@@ -219,7 +208,8 @@ decode_integer(<<Char, Rest/bitstring>>, Buffer)
 %    end.
 
 %%--------------------------------------------------------------------
-%%
+%% @doc
+%% @end
 %%--------------------------------------------------------------------
 decode_bulk_string(<<"-1\r\n">>) ->
     {ok, nil};
@@ -235,7 +225,8 @@ decode_bulk_string(Bitstring) ->
     end.
              
 %%--------------------------------------------------------------------
-%%
+%% @doc
+%% @end
 %%--------------------------------------------------------------------
 decode_array(<<"0\r\n">>) ->
     {ok, []};
@@ -258,7 +249,8 @@ decode_array(Bitstring, Size, Buffer) ->
     end.
 
 %%--------------------------------------------------------------------
-%%
+%% @doc
+%% @end
 %%--------------------------------------------------------------------
 decode_error(Bitstring) ->
     decode_error(Bitstring, <<>>).

--- a/src/redis.hrl
+++ b/src/redis.hrl
@@ -1,0 +1,13 @@
+%-type encode_error() :: {error, bitstring() | binary()}.
+-type encode_integer() :: integer().
+-type encode_string() :: bitstring() | binary().
+-type encode_bulk_string() :: {bulk_string, bitstring() | null} | list() | {error, binary()}.
+-type encode_array() :: [encode_integer() |
+                         encode_string() |
+                         encode_bulk_string()].
+-type encode_types() :: encode_integer() | 
+                        encode_string() |
+                        encode_bulk_string() |
+                        encode_array().
+-type encode_return_ok() :: bitstring() | binary().
+-type encode_return_error() :: {error, atom()}.

--- a/src/redis_command.erl
+++ b/src/redis_command.erl
@@ -1,0 +1,90 @@
+%%%-------------------------------------------------------------------
+%%% @doc
+%%% @end
+%%%-------------------------------------------------------------------
+-module(redis_command).
+-compile(export_all).
+-compile({no_auto_import,[get/0]}).
+-include("redis.hrl").
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec copy() -> Return when
+      Return :: encode_bulk_string().
+copy() -> 
+    {bulk_string, <<"COPY">>}.
+
+-spec copy(Source, Destination) -> Return when
+      Source :: encode_bulk_string(),
+      Destination :: encode_bulk_string(),
+      Return :: any().
+
+copy(Source, Destination) ->
+    copy(Source, Destination, []).
+
+-spec copy(Source, Destination, Args) -> Return when
+      Source :: encode_bulk_string(),
+      Destination :: encode_bulk_string(),
+      Args :: list(),
+      Return :: any().
+copy(Source, Destination, _Args) ->
+    Command = [copy(), Source, Destination],
+    redis:encode(Command).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec del() -> Return when
+      Return :: {bulk_string, bitstring()}.
+del() -> {bulk_string, <<"DEL">>}.
+
+-spec del(Keys) -> Return when
+      Keys :: encode_bulk_string(),
+      Return :: any().
+del(Keys) ->
+    Command = [del()|Keys],
+    redis:encode(Command).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+-spec set() -> Return when
+      Return :: encode_bulk_string().
+set() ->
+    {bulk_string, <<"SET">>}.
+
+-spec set(Key, Value) -> Return when
+      Key :: encode_bulk_string(),
+      Value :: encode_types(),
+      Return :: any().
+set(Key, Value) ->
+    set(Key, Value, []).
+
+-spec set(Key, Value, Args) -> Return when
+      Key :: encode_bulk_string(),
+      Value :: encode_types(),
+      Args :: list(),
+      Return :: any().
+set(Key, Value, _Args) ->
+    Command = [set(), Key, Value],
+    redis:encode(Command).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------
+get() ->
+    {bulk_string, <<"GET">>}.
+
+get(Key) ->
+    Command = [get(), Key],
+    redis:encode(Command).
+
+%%--------------------------------------------------------------------
+%% @doc
+%% @end
+%%--------------------------------------------------------------------

--- a/src/redis_command.erl
+++ b/src/redis_command.erl
@@ -1,21 +1,38 @@
 %%%-------------------------------------------------------------------
-%%% @doc
+%%% @doc https://redis.io/commands#
+%%%
+%%% @todo copy
+%%% @todo del
+%%% @todo set
+%%% @todo get
+%%% @todo getdel
+%%% @todo strlen
+%%% @todo append
+%%% 
 %%% @end
 %%%-------------------------------------------------------------------
 -module(redis_command).
--compile(export_all).
 -compile({no_auto_import,[get/0]}).
 -include("redis.hrl").
+-export([copy/0, copy/2, copy/3]).
+-export([del/0, del/1]).
+-export([set/0, set/2, set/3]).
+-export([get/0, get/1]).
 
 %%--------------------------------------------------------------------
-%% @doc
+%% @doc copy/0.
 %% @end
 %%--------------------------------------------------------------------
 -spec copy() -> Return when
       Return :: encode_bulk_string().
+
 copy() -> 
     {bulk_string, <<"COPY">>}.
 
+%%--------------------------------------------------------------------
+%% @doc copy/2.
+%% @end
+%%--------------------------------------------------------------------
 -spec copy(Source, Destination) -> Return when
       Source :: encode_bulk_string(),
       Destination :: encode_bulk_string(),
@@ -24,67 +41,100 @@ copy() ->
 copy(Source, Destination) ->
     copy(Source, Destination, []).
 
+%%--------------------------------------------------------------------
+%% @doc copy/3.
+%% @end
+%%--------------------------------------------------------------------
 -spec copy(Source, Destination, Args) -> Return when
       Source :: encode_bulk_string(),
       Destination :: encode_bulk_string(),
       Args :: list(),
       Return :: any().
+
 copy(Source, Destination, _Args) ->
     Command = [copy(), Source, Destination],
     redis:encode(Command).
 
 %%--------------------------------------------------------------------
-%% @doc
+%% @doc del/0.
 %% @end
 %%--------------------------------------------------------------------
 -spec del() -> Return when
-      Return :: {bulk_string, bitstring()}.
+      Return :: encode_bulk_string().
+
 del() -> {bulk_string, <<"DEL">>}.
 
+%%--------------------------------------------------------------------
+%% @doc del/1.
+%% @end
+%%--------------------------------------------------------------------
 -spec del(Keys) -> Return when
       Keys :: encode_bulk_string(),
       Return :: any().
+
 del(Keys) ->
     Command = [del()|Keys],
     redis:encode(Command).
 
 %%--------------------------------------------------------------------
-%% @doc
+%% @doc set/0.
 %% @end
 %%--------------------------------------------------------------------
 -spec set() -> Return when
       Return :: encode_bulk_string().
+
 set() ->
     {bulk_string, <<"SET">>}.
 
+%%--------------------------------------------------------------------
+%% @doc set/0.
+%% @end
+%%--------------------------------------------------------------------
 -spec set(Key, Value) -> Return when
       Key :: encode_bulk_string(),
       Value :: encode_types(),
       Return :: any().
+
 set(Key, Value) ->
     set(Key, Value, []).
 
+%%--------------------------------------------------------------------
+%% @doc set/0.
+%% @end
+%%--------------------------------------------------------------------
 -spec set(Key, Value, Args) -> Return when
       Key :: encode_bulk_string(),
       Value :: encode_types(),
       Args :: list(),
       Return :: any().
+
 set(Key, Value, _Args) ->
     Command = [set(), Key, Value],
     redis:encode(Command).
 
 %%--------------------------------------------------------------------
-%% @doc
+%% @doc get/0.
 %% @end
 %%--------------------------------------------------------------------
+-spec get() -> Return when
+      Return :: encode_bulk_string().
+
 get() ->
     {bulk_string, <<"GET">>}.
+
+%%--------------------------------------------------------------------
+%% @doc get/0.
+%% @end
+%%--------------------------------------------------------------------
+-spec get(Key) -> Return when
+      Key :: encode_bulk_string(),
+      Return :: any().
 
 get(Key) ->
     Command = [get(), Key],
     redis:encode(Command).
 
 %%--------------------------------------------------------------------
-%% @doc
+%% @doc getdel/0.
 %% @end
 %%--------------------------------------------------------------------


### PR DESCRIPTION
This is a simple implementation of commands from client side. The list of these commands are available on [Command References](https://redis.io/commands). Only a few subset is implemented.

- [ ] `GET`: https://redis.io/commands/get
- [ ] `DEL`: https://redis.io/commands/del
- [ ] `SET`: https://redis.io/commands/set
- [ ] `COPY`: https://redis.io/commands/copy
- [ ] `GETDEL`: https://redis.io/commands/getdel
- [ ] `STRLEN`: https://redis.io/commands/strlen
- [ ] `APPEND`: https://redis.io/commands/append

The goal is to generate a valid payload, usable on official redis server.